### PR TITLE
Force mode array to be a list

### DIFF
--- a/bilby_lisa/source.py
+++ b/bilby_lisa/source.py
@@ -93,6 +93,8 @@ def lisa_binary_black_hole(
         waveform_approximant="BBHx_IMRPhenomD", relative=False,
     )
     waveform_kwargs.update(kwargs)
+    if isinstance(waveform_kwargs["mode_array"], tuple):
+        waveform_kwargs["mode_array"] = list(waveform_kwargs["mode_array"])
     _channels_to_calculate = [
         _ for _ in waveform_kwargs["ifos"] if _ in _implemented_channels
     ]


### PR DESCRIPTION
`BBHx` requires the `mode-array` to be a list of lists, and `bilby_pipe` passes it as a tuple of lists. This therefore causes errors when trying to generate a waveform with a specific set of multipoles. This MR forces `mode-array` to be a list of lists if a tuple is provided.